### PR TITLE
Fix schedule API window timezone calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,22 +919,33 @@ async function tryPopulateScheduleFromScheduleAPI() {
   const tz = CONFIG.timeZone || 'Pacific/Auckland';
   const daysOrder = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 
-  // Build a 7-day window starting today in target TZ
-  const parts = new Intl.DateTimeFormat('en-GB', { timeZone: tz, year:'numeric', month:'2-digit', day:'2-digit' })
-    .formatToParts(new Date()).reduce((o,p)=>(o[p.type]=p.value,o),{});
-  const startLocal = new Date(`${parts.year}-${parts.month}-${parts.day}T00:00:00`);
-  const endLocal   = new Date(startLocal.getTime() + 7*24*60*60*1000);
-
   const offsetPart = (d) => {
     const p = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'shortOffset' }).formatToParts(d);
     const v = p.find(x => x.type === 'timeZoneName')?.value || 'GMT+00';
     const m = v.match(/GMT([+\-])(\d{1,2})(?::?(\d{2}))?/);
     return m ? `${m[1]}${m[2].padStart(2,'0')}:${(m[3]||'00').padStart(2,'0')}` : '+00:00';
   };
+  const offsetInfo = (d) => {
+    const offset = offsetPart(d);
+    const m = offset.match(/([+\-])(\d{2}):(\d{2})/);
+    const sign = (m?.[1] === '-') ? -1 : 1;
+    const minutes = m ? sign * ((Number(m[2]) || 0) * 60 + (Number(m[3]) || 0)) : 0;
+    return { offset, minutes };
+  };
+
+  // Build a 7-day window starting today in target TZ
+  const parts = new Intl.DateTimeFormat('en-GB', { timeZone: tz, year:'numeric', month:'2-digit', day:'2-digit' })
+    .formatToParts(new Date()).reduce((o,p)=>(o[p.type]=p.value,o),{});
+  const baseUTC = Date.UTC(Number(parts.year), Number(parts.month) - 1, Number(parts.day));
+  const startInfo = offsetInfo(new Date(baseUTC));
+  const startLocal = new Date(baseUTC - startInfo.minutes * 60 * 1000);
+  const endLocal   = new Date(startLocal.getTime() + 7*24*60*60*1000);
+
   const fmtISO = (d) => {
+    const { offset } = offsetInfo(d);
     const p = new Intl.DateTimeFormat('en-GB', { timeZone: tz, year:'numeric', month:'2-digit', day:'2-digit', hour:'2-digit', minute:'2-digit', second:'2-digit', hour12:false })
       .formatToParts(d).reduce((o,p)=>(o[p.type]=p.value,o),{});
-    return `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}:00${offsetPart(d)}`;
+    return `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}:${p.second || '00'}${offset}`;
   };
 
   const url = `${CONFIG.apiBase}/station/${CONFIG.stationId}/schedule`


### PR DESCRIPTION
## Summary
- ensure the schedule window starts at midnight in the configured station timezone by adjusting the Date.UTC timestamp with the station offset
- reuse the shared offset helper when building ISO timestamps so API requests always include the station offset rather than the viewer locale

## Testing
- TZ=Europe/London node /tmp/test_schedule.js

------
https://chatgpt.com/codex/tasks/task_e_68de4071203c8329abc1596b04cea166