### PR TITLE
Adjust pull script to self-update repository location

### DIFF
--- a/scripts/pull_repo.sh
+++ b/scripts/pull_repo.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Fetches the AmpedAIWeb repository into a local directory. Intended for use
+# in cron jobs where you want to keep a local clone up to date without
+# interactive maintenance.
+#
+# Usage:
+#   ./pull_repo.sh [target_directory]
+#
+# Environment variables:
+#   REPO_URL - Override the repository URL to clone. Defaults to the public GitHub repo.
+#   BRANCH   - Branch to checkout/reset to. Defaults to "main".
+#
+# When run without arguments the script keeps the repository in the directory
+# that contains the script. If the script lives inside a directory named
+# "scripts" (as it does in this repository), the parent directory is used so the
+# repository root stays one level up. This makes it convenient for cron jobs
+# that should self-update.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_TARGET="$SCRIPT_DIR"
+if [[ "$(basename "$SCRIPT_DIR")" == "scripts" ]]; then
+  DEFAULT_TARGET="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+REPO_URL="${REPO_URL:-https://github.com/trogy/AmpedAIWeb.git}"
+TARGET_DIR="${1:-$DEFAULT_TARGET}"
+BRANCH="${BRANCH:-main}"
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+fatal() {
+  log "ERROR: $*"
+  exit 1
+}
+
+[[ -n "$REPO_URL" ]] || fatal "REPO_URL must be provided via environment variable or default"
+
+command -v git >/dev/null 2>&1 || fatal "git is not installed or not in PATH"
+
+mkdir -p "$TARGET_DIR"
+
+git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  log "Initializing git repository at $TARGET_DIR"
+  git -C "$TARGET_DIR" init >/dev/null \
+    || fatal "Failed to initialize git repository in $TARGET_DIR"
+}
+
+git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || fatal "$TARGET_DIR exists but is not a git repository"
+
+CURRENT_REMOTE="$(git -C "$TARGET_DIR" remote get-url origin 2>/dev/null || true)"
+if [[ -n "$CURRENT_REMOTE" ]]; then
+  if [[ "$CURRENT_REMOTE" != "$REPO_URL" ]]; then
+    log "Updating origin remote from $CURRENT_REMOTE to $REPO_URL"
+    git -C "$TARGET_DIR" remote set-url origin "$REPO_URL" \
+      || fatal "Failed to update origin remote"
+  fi
+else
+  log "Setting origin remote to $REPO_URL"
+  git -C "$TARGET_DIR" remote add origin "$REPO_URL" \
+    || fatal "Failed to add origin remote"
+fi
+
+git -C "$TARGET_DIR" fetch --prune --tags origin \
+  || fatal "Failed to fetch updates from $REPO_URL"
+
+if ! git -C "$TARGET_DIR" rev-parse --verify --quiet "origin/$BRANCH"; then
+  fatal "Branch $BRANCH does not exist on origin"
+fi
+
+if git -C "$TARGET_DIR" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git -C "$TARGET_DIR" checkout -f "$BRANCH" >/dev/null \
+    || fatal "Failed to checkout branch $BRANCH"
+else
+  log "Creating local branch $BRANCH from origin/$BRANCH"
+  git -C "$TARGET_DIR" branch -f "$BRANCH" "origin/$BRANCH" >/dev/null \
+    || fatal "Failed to create branch $BRANCH"
+  git -C "$TARGET_DIR" checkout -f "$BRANCH" >/dev/null \
+    || fatal "Failed to switch to branch $BRANCH"
+fi
+
+git -C "$TARGET_DIR" reset --hard "origin/$BRANCH" \
+  || fatal "Failed to reset branch $BRANCH to origin"
+
+git -C "$TARGET_DIR" branch --set-upstream-to="origin/$BRANCH" "$BRANCH" >/dev/null 2>&1 || true
+
+log "Repository ready at $TARGET_DIR on branch $BRANCH"
+


### PR DESCRIPTION
## Summary
- default the pull helper to manage the repository in the directory that hosts the script so cron jobs update themselves
- allow initialisation in pre-existing directories by creating the git repo in place and wiring the origin remote automatically
- force branch checkout/reset to guarantee the working tree matches the requested origin branch on each run

## Testing
- not run (script-only change)

------
https://chatgpt.com/codex/tasks/task_e_68de5a373b0483299adaa3ff502d84f3