### PR TITLE
Update pull_repo canonical path guard

### DIFF
--- a/scripts/pull_repo.sh
+++ b/scripts/pull_repo.sh
@@ -48,7 +48,10 @@ command -v git >/dev/null 2>&1 || fatal "git is not installed or not in PATH"
 
 mkdir -p "$TARGET_DIR"
 
-RESTORE_PWD=""
+TARGET_DIR_CANONICAL="$(cd "$TARGET_DIR" && pwd -P)"
+CALLER_CANONICAL="$(pwd -P)"
+
+RESTORE_PWD="$PWD"
 restore_pwd() {
   if [[ -z "$RESTORE_PWD" ]]; then
     return
@@ -61,6 +64,10 @@ restore_pwd() {
   fi
 }
 trap restore_pwd EXIT
+
+if [[ "$CALLER_CANONICAL" == "$TARGET_DIR_CANONICAL" || "$CALLER_CANONICAL" == "$TARGET_DIR_CANONICAL"/* ]]; then
+  fatal "Refusing to run inside target directory $TARGET_DIR"
+fi
 
 if ! git -C "$TARGET_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if [[ "$TARGET_DIR" == "/" ]]; then


### PR DESCRIPTION
## Summary
- capture canonical versions of the target directory and caller directory when preparing to run
- guard against running the script from inside the target directory using canonical path comparisons
- preserve the original logical working directory for the exit trap to restore when possible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df1bba32588329a997243ee6643304