### PR TITLE
Move volume control below now playing card

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,6 +348,11 @@
                 height: 36px;
           }
 
+          .promo-card .player-volume {
+                margin-top: 1.2rem;
+                width: 100%;
+          }
+
           .promo-card {
                 position: relative;
                 overflow: hidden;
@@ -847,19 +852,6 @@
               </svg>
               <span>Play Stream</span>
             </button>
-            <div class="player-volume" role="group" aria-label="Volume controls">
-              <label for="volumeControl">Volume</label>
-              <div class="player-volume-controls">
-                <input id="volumeControl" name="volume" type="range" min="0" max="100" step="1" value="100" aria-valuemin="0" aria-valuemax="100" />
-                <button type="button" id="muteBtn" class="icon-btn" aria-pressed="false" aria-label="Mute audio" title="Mute audio">
-                  <svg id="muteIcon" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                    <path d="M4 9v6h4l5 5V4L8 9H4Z"/>
-                    <path d="M16 12a4 4 0 0 0-2.3-3.6l.8-1.8A6 6 0 0 1 18 12a6 6 0 0 1-3.5 5.4l-.8-1.8A4 4 0 0 0 16 12Z"/>
-                  </svg>
-                  <span id="muteText" class="sr-only">Mute audio</span>
-                </button>
-              </div>
-            </div>
           </div>
           <a class="btn btn-ghost" href="#schedule">View Schedule</a>
           <a class="btn btn-ghost" href="#recent">Recently Played</a>
@@ -873,9 +865,9 @@
             <img id="artImg" alt="Album art" src="">
             <span id="artFallback">AMP</span>
           </div>
-		<div class="track" aria-live="polite" aria-atomic="true">
-		  <h3 id="trackTitle">Track Title</h3>
-		  <p id="trackMeta">Artist • with <strong id="trackHost">Host</strong></p>
+          <div class="track" aria-live="polite" aria-atomic="true">
+            <h3 id="trackTitle">Track Title</h3>
+            <p id="trackMeta">Artist • with <strong id="trackHost">Host</strong></p>
             <div class="progress" aria-label="Progress">
               <div class="bar" id="progressBar" style="width:0%"></div>
             </div>
@@ -885,6 +877,19 @@
               <span class="live-dot" aria-hidden></span>
               <span id="liveLabel">Live</span>
             </span>
+          </div>
+        </div>
+        <div class="player-volume" role="group" aria-label="Volume controls">
+          <label for="volumeControl">Volume</label>
+          <div class="player-volume-controls">
+            <input id="volumeControl" name="volume" type="range" min="0" max="100" step="1" value="100" aria-valuemin="0" aria-valuemax="100" />
+            <button type="button" id="muteBtn" class="icon-btn" aria-pressed="false" aria-label="Mute audio" title="Mute audio">
+              <svg id="muteIcon" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                <path d="M4 9v6h4l5 5V4L8 9H4Z"/>
+                <path d="M16 12a4 4 0 0 0-2.3-3.6l.8-1.8A6 6 0 0 1 18 12a6 6 0 0 1-3.5 5.4l-.8-1.8A4 4 0 0 0 16 12Z"/>
+              </svg>
+              <span id="muteText" class="sr-only">Mute audio</span>
+            </button>
           </div>
         </div>
         <audio id="player" preload="none" crossorigin="anonymous"></audio>


### PR DESCRIPTION
## Summary
- relocate the volume slider and mute toggle into the now playing promo card
- add promo-specific spacing so the relocated control stretches across the card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2bc153308329aedaadb940d08e5b