### PR TITLE
Add animated pulse effect to live indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -502,14 +502,45 @@
 		font-size: .9rem;
 	  }
 
-	  .live-dot {
-		width: 10px;
-		height: 10px;
-		border-radius: 50%;
-		background: #ff4d9a;
-		box-shadow: 0 0 0 6px rgba(255, 77, 154, .12);
-		display: inline-block;
-	  }
+          @keyframes livePulse {
+                0% {
+                      transform: scale(1);
+                      opacity: 1;
+                      box-shadow: 0 0 0 0 rgba(255, 77, 154, .28), 0 0 12px rgba(255, 77, 154, .5);
+                }
+
+                55% {
+                      transform: scale(1.45);
+                      opacity: .35;
+                      box-shadow: 0 0 0 8px rgba(255, 77, 154, 0), 0 0 18px rgba(255, 77, 154, .28);
+                }
+
+                100% {
+                      transform: scale(1);
+                      opacity: 1;
+                      box-shadow: 0 0 0 0 rgba(255, 77, 154, 0), 0 0 12px rgba(255, 77, 154, .4);
+                }
+          }
+
+          .live-dot {
+                width: 10px;
+                height: 10px;
+                border-radius: 50%;
+                background: #ff4d9a;
+                box-shadow: 0 0 0 0 rgba(255, 77, 154, .28), 0 0 10px rgba(255, 77, 154, .32);
+                display: inline-block;
+                animation: livePulse 1.8s ease-in-out infinite;
+                will-change: transform, opacity;
+          }
+
+          @media (prefers-reduced-motion: reduce) {
+                .live-dot {
+                      animation: none;
+                      transform: none;
+                      opacity: 1;
+                      box-shadow: 0 0 0 6px rgba(255, 77, 154, .12);
+                }
+          }
 
 	  .progress {
 		height: 6px;


### PR DESCRIPTION
## Summary
- add a livePulse keyframe animation for the live status indicator
- update the live-dot styling to use the new animation and improve rendering quality
- provide a reduced-motion fallback that keeps the indicator static

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df2e2447908329a689024537e163f5