### PR TITLE
Add hero and promo fade-up animations with reduced motion support

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 	<meta name="theme-color" content="#ff4db8" />
 	<meta name="color-scheme" content="dark light">
 
-	<style>
+        <style>
           :root {
                 --brand-h: 330;
                 --brand-s: 100%;
@@ -62,6 +62,18 @@
                 --r-sm: 10px;
                 --max: 1100px;
                 --promo-texture: none;
+          }
+
+          @keyframes heroFadeUp {
+                from {
+                  opacity: 0;
+                  transform: translateY(20px);
+                }
+
+                to {
+                  opacity: 1;
+                  transform: translateY(0);
+                }
           }
 
 	  [data-theme="light"] {
@@ -262,42 +274,60 @@
 		padding: 48px 0 26px;
 	  }
 
-	  .hero .wrap {
-		display: grid;
-		grid-template-columns: 1.2fr .8fr;
-		gap: 28px;
-		align-items: center;
-	  }
+          .hero .wrap {
+                display: grid;
+                grid-template-columns: 1.2fr .8fr;
+                gap: 28px;
+                align-items: center;
+          }
 
-	  .eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: .5rem;
-		font-weight: 600;
-		color: var(--brand-300);
-		letter-spacing: .3px;
-	  }
+          .hero .eyebrow,
+          .hero h1,
+          .hero p,
+          .hero .cta,
+          .promo-card,
+          .up-next-card {
+                opacity: 0;
+                transform: translateY(20px);
+                animation: heroFadeUp .8s ease forwards;
+          }
 
-	  .hero h1 {
-		font-size: clamp(2rem, 1.2rem + 3vw, 3.2rem);
-		margin: .4rem 0 .75rem;
-		line-height: 1.1;
-	  }
+          .eyebrow {
+                display: inline-flex;
+                align-items: center;
+                gap: .5rem;
+                font-weight: 600;
+                color: var(--brand-300);
+                letter-spacing: .3px;
+          }
 
-	  .hero h1 span {
-		color: var(--brand-300);
-	  }
+          .hero .eyebrow {
+                animation-delay: .1s;
+          }
 
-	  .hero p {
-		color: var(--muted);
-		max-width: 48ch;
-	  }
+          .hero h1 {
+                font-size: clamp(2rem, 1.2rem + 3vw, 3.2rem);
+                margin: .4rem 0 .75rem;
+                line-height: 1.1;
+                animation-delay: .2s;
+          }
+
+          .hero h1 span {
+                color: var(--brand-300);
+          }
+
+          .hero p {
+                color: var(--muted);
+                max-width: 48ch;
+                animation-delay: .3s;
+          }
 
           .hero .cta {
                 display: flex;
                 gap: .6rem;
                 margin-top: 1rem;
                 flex-wrap: wrap;
+                animation-delay: .4s;
           }
 
           .player-controls {
@@ -365,6 +395,7 @@
                 border-radius: var(--r-lg);
                 padding: 18px;
                 box-shadow: var(--shadow);
+                animation-delay: .25s;
           }
 
           .promo-card .promo-accent {
@@ -394,6 +425,7 @@
 
           .up-next-card {
                 margin-top: 18px;
+                animation-delay: .35s;
           }
 
           .up-next-head {
@@ -794,10 +826,21 @@
 		transform: scale(1.03);
 	  }
 	  
-	  @media (prefers-reduced-motion: reduce) {
-		.card .media img { transition: none; }
-	  }
-	</style>
+          @media (prefers-reduced-motion: reduce) {
+                .card .media img { transition: none; }
+
+                .hero .eyebrow,
+                .hero h1,
+                .hero p,
+                .hero .cta,
+                .promo-card,
+                .up-next-card {
+                  opacity: 1 !important;
+                  transform: none !important;
+                  animation: none !important;
+                }
+          }
+        </style>
 </head>
 <body>
   <a class="skip" href="#main">Skip to content</a>


### PR DESCRIPTION
## Summary
- add a heroFadeUp keyframe animation for hero and promo content
- apply staggered entrance animations to hero text and promo/up-next cards
- respect prefers-reduced-motion by disabling the animations when requested

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df2e22440483299d0fcd413936b8b6