### PR TITLE
Add main landmark around homepage sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,86 +914,87 @@
     </div>
   </header>
 
-<section class="hero" id="listen">
-  <div class="container">
-    <div class="wrap">
-      <div>
-        <div class="eyebrow">
-          <span class="chip"><span class="live-dot" aria-hidden></span> Live 24/7</span>
-          <span class="neon">100% AI Radio</span>
-        </div>
+  <main id="main">
+    <section class="hero" id="listen">
+      <div class="container">
+        <div class="wrap">
+          <div>
+            <div class="eyebrow">
+              <span class="chip"><span class="live-dot" aria-hidden></span> Live 24/7</span>
+              <span class="neon">100% AI Radio</span>
+            </div>
 
-        <h1><span>Amped AI</span> — Always on. Always different.</h1>
+            <h1><span>Amped AI</span> — Always on. Always different.</h1>
 
-        <p>
-          A new kind of station: AI-generated music, shows, and voices.
-          Streaming non-stop with real programming, real hosts, and zero humans behind the mic.
-        </p>
+            <p>
+              A new kind of station: AI-generated music, shows, and voices.
+              Streaming non-stop with real programming, real hosts, and zero humans behind the mic.
+            </p>
 
-        <div class="cta">
-          <div class="player-controls" role="group" aria-label="Player controls">
-            <button id="playBtn" class="btn btn-primary" aria-pressed="false">
-              <svg id="playIcon" viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden>
-                <path d="m8 5 12 7-12 7V5Z"/>
-              </svg>
-              <span>Play Stream</span>
-            </button>
-          </div>
-          <a class="btn btn-ghost" href="#schedule">View Schedule</a>
-          <a class="btn btn-ghost" href="#recent">Recently Played</a>
-        </div>
-      </div>
-
-      <aside class="promo-card" aria-label="Now playing">
-        <img id="hostAccent" class="promo-accent" alt="" aria-hidden="true" hidden>
-        <div class="now">
-          <div class="art">
-            <img id="artImg" alt="Album art" src="">
-            <span id="artFallback">AMP</span>
-          </div>
-          <div class="track" aria-live="polite" aria-atomic="true">
-            <h3 id="trackTitle">Track Title</h3>
-            <p id="trackMeta">Artist • with <strong id="trackHost">Host</strong></p>
-            <div class="progress" aria-label="Progress">
-              <div class="bar" id="progressBar" style="width:0%"></div>
+            <div class="cta">
+              <div class="player-controls" role="group" aria-label="Player controls">
+                <button id="playBtn" class="btn btn-primary" aria-pressed="false">
+                  <svg id="playIcon" viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden>
+                    <path d="m8 5 12 7-12 7V5Z"/>
+                  </svg>
+                  <span>Play Stream</span>
+                </button>
+              </div>
+              <a class="btn btn-ghost" href="#schedule">View Schedule</a>
+              <a class="btn btn-ghost" href="#recent">Recently Played</a>
             </div>
           </div>
-          <div>
-            <span class="chip" title="Live">
-              <span class="live-dot" aria-hidden></span>
-              <span id="liveLabel">Live</span>
-            </span>
+
+          <aside class="promo-card" aria-label="Now playing">
+            <img id="hostAccent" class="promo-accent" alt="" aria-hidden="true" hidden>
+            <div class="now">
+              <div class="art">
+                <img id="artImg" alt="Album art" src="">
+                <span id="artFallback">AMP</span>
+              </div>
+              <div class="track" aria-live="polite" aria-atomic="true">
+                <h3 id="trackTitle">Track Title</h3>
+                <p id="trackMeta">Artist • with <strong id="trackHost">Host</strong></p>
+                <div class="progress" aria-label="Progress">
+                  <div class="bar" id="progressBar" style="width:0%"></div>
+                </div>
+              </div>
+              <div>
+                <span class="chip" title="Live">
+                  <span class="live-dot" aria-hidden></span>
+                  <span id="liveLabel">Live</span>
+                </span>
+              </div>
+            </div>
+            <div class="player-volume" role="group" aria-label="Volume controls">
+              <label for="volumeControl">Volume</label>
+              <div class="player-volume-controls">
+                <input id="volumeControl" name="volume" type="range" min="0" max="100" step="1" value="100" aria-valuemin="0" aria-valuemax="100" />
+                <button type="button" id="muteBtn" class="icon-btn" aria-pressed="false" aria-label="Mute audio" title="Mute audio">
+                  <svg id="muteIcon" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                    <path d="M4 9v6h4l5 5V4L8 9H4Z"/>
+                    <path d="M16 12a4 4 0 0 0-2.3-3.6l.8-1.8A6 6 0 0 1 18 12a6 6 0 0 1-3.5 5.4l-.8-1.8A4 4 0 0 0 16 12Z"/>
+                  </svg>
+                  <span id="muteText" class="sr-only">Mute audio</span>
+                </button>
+              </div>
+            </div>
+            <audio id="player" preload="none" crossorigin="anonymous"></audio>
+          </aside>
+          <div class="card up-next-card" id="upNextCard" aria-live="polite">
+            <div class="body">
+              <div class="up-next-head">
+                <span class="chip">Up Next</span>
+                <span class="meta" id="upNextTzLabel"></span>
+              </div>
+              <ol id="upNextList" class="up-next-list">
+                <li class="meta">Loading schedule…</li>
+              </ol>
+            </div>
           </div>
-        </div>
-        <div class="player-volume" role="group" aria-label="Volume controls">
-          <label for="volumeControl">Volume</label>
-          <div class="player-volume-controls">
-            <input id="volumeControl" name="volume" type="range" min="0" max="100" step="1" value="100" aria-valuemin="0" aria-valuemax="100" />
-            <button type="button" id="muteBtn" class="icon-btn" aria-pressed="false" aria-label="Mute audio" title="Mute audio">
-              <svg id="muteIcon" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                <path d="M4 9v6h4l5 5V4L8 9H4Z"/>
-                <path d="M16 12a4 4 0 0 0-2.3-3.6l.8-1.8A6 6 0 0 1 18 12a6 6 0 0 1-3.5 5.4l-.8-1.8A4 4 0 0 0 16 12Z"/>
-              </svg>
-              <span id="muteText" class="sr-only">Mute audio</span>
-            </button>
-          </div>
-        </div>
-        <audio id="player" preload="none" crossorigin="anonymous"></audio>
-      </aside>
-      <div class="card up-next-card" id="upNextCard" aria-live="polite">
-        <div class="body">
-          <div class="up-next-head">
-            <span class="chip">Up Next</span>
-            <span class="meta" id="upNextTzLabel"></span>
-          </div>
-          <ol id="upNextList" class="up-next-list">
-            <li class="meta">Loading schedule…</li>
-          </ol>
         </div>
       </div>
-    </div>
-  </div>
-</section>
+    </section>
 
     <section id="shows">
       <div class="container">
@@ -1023,66 +1024,67 @@
       </div>
     </section>
 
-	<section id="about">
-	  <div class="container">
-		<h2 class="neon">About Amped AI</h2>
-		<div class="grid" style="align-items:center">
-		  
-		  <!-- Group photo -->
-		  <div class="col-6">
-			<div class="card">
-			  <div class="media" style="aspect-ratio:3/2; overflow:hidden; background:var(--surface-2);">
-				<img src="GroupPhoto.jpg" alt="Amped AI on-air hosts" width="1200" height="800" loading="lazy" style="width:100%; height:100%; object-fit:cover;">
-			  </div>
-			</div>
-		  </div>
+    <section id="about">
+      <div class="container">
+        <h2 class="neon">About Amped AI</h2>
+        <div class="grid" style="align-items:center">
 
-		  <!-- Station Info -->
-		  <div class="col-6">
-			<div class="card">
-			  <div class="body">
-				<p>
-				  Amped AI is a fully automated radio station running around the clock.  
-				  Shows are written by large language models, voiced using advanced text-to-speech,  
-				  and scheduled with AzuraCast. Every track played is AI-generated music, making the  
-				  station a complete end-to-end experiment in machine-driven broadcasting.
-				</p>
-				<p>
-				  The goal is simple: see how close AI can get to creating the energy and flow of  
-				  traditional radio, while opening the door to new kinds of programming that wouldn’t  
-				  be possible with a fixed human schedule.
-				</p>
-				<div style="display:flex; gap:8px; flex-wrap:wrap; margin-top:6px;">
-				  <span class="chip">Live 24/7</span>
-				  <span class="chip">Powered by AzuraCast</span>
-				  <span class="chip">AI Hosts</span>
-				  <span class="chip">100% AI Music</span>
-				</div>
-			  </div>
-			</div>
-		  </div>
+          <!-- Group photo -->
+          <div class="col-6">
+            <div class="card">
+              <div class="media" style="aspect-ratio:3/2; overflow:hidden; background:var(--surface-2);">
+                <img src="GroupPhoto.jpg" alt="Amped AI on-air hosts" width="1200" height="800" loading="lazy" style="width:100%; height:100%; object-fit:cover;">
+              </div>
+            </div>
+          </div>
 
-		</div>
-	  </div>
-	</section>
+          <!-- Station Info -->
+          <div class="col-6">
+            <div class="card">
+              <div class="body">
+                <p>
+                  Amped AI is a fully automated radio station running around the clock.
+                  Shows are written by large language models, voiced using advanced text-to-speech,
+                  and scheduled with AzuraCast. Every track played is AI-generated music, making the
+                  station a complete end-to-end experiment in machine-driven broadcasting.
+                </p>
+                <p>
+                  The goal is simple: see how close AI can get to creating the energy and flow of
+                  traditional radio, while opening the door to new kinds of programming that wouldn’t
+                  be possible with a fixed human schedule.
+                </p>
+                <div style="display:flex; gap:8px; flex-wrap:wrap; margin-top:6px;">
+                  <span class="chip">Live 24/7</span>
+                  <span class="chip">Powered by AzuraCast</span>
+                  <span class="chip">AI Hosts</span>
+                  <span class="chip">100% AI Music</span>
+                </div>
+              </div>
+            </div>
+          </div>
 
+        </div>
+      </div>
+    </section>
 
-<section id="ethics" style="margin-top:4rem;">
-  <div class="container">
-    <div class="card">
-      <div class="body" style="text-align:center;">
-        <h3 class="neon">Ethics & Transparency</h3>
-        <p style="max-width:720px; margin:0 auto;">
-          Amped AI is an experiment — a side project, not a full-time job for anyone involved.  
-          If people enjoy it, great; if not, that’s fine too. The goal isn’t to replace radio DJs or take work away.  
-          Every show you hear is fully generated using a mix of large language models and ElevenLabs text-to-speech, 
-          with light human curation to keep things sensible and safe.
-        </p>
-      	<br>
-	</div>
-    </div>
-  </div>
-</section>
+    <section id="ethics" style="margin-top:4rem;">
+      <div class="container">
+        <div class="card">
+          <div class="body" style="text-align:center;">
+            <h3 class="neon">Ethics & Transparency</h3>
+            <p style="max-width:720px; margin:0 auto;">
+              Amped AI is an experiment — a side project, not a full-time job for anyone involved.
+              If people enjoy it, great; if not, that’s fine too. The goal isn’t to replace radio DJs or take work away.
+              Every show you hear is fully generated using a mix of large language models and ElevenLabs text-to-speech,
+              with light human curation to keep things sensible and safe.
+            </p>
+            <br>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
 
   <footer>
     <div class="container footer-grid">


### PR DESCRIPTION
## Summary
- wrap the primary homepage sections in a `<main id="main">` landmark so the skip link has a valid target
- adjust indentation for the affected sections to match the new structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df4fd696088329b970d2bba35e16f6