### PR TITLE
Make Up Next card span full hero width

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,6 +425,7 @@
 
           .up-next-card {
                 margin-top: 18px;
+                grid-column: 1 / -1;
                 animation-delay: .35s;
           }
 
@@ -718,14 +719,18 @@
                 gap: 10px;
           }
 
-	  @media (max-width: 900px) {
-		.hero .wrap {
-		  grid-template-columns: 1fr;
-		}
+          @media (max-width: 900px) {
+                .hero .wrap {
+                  grid-template-columns: 1fr;
+                }
 
-		.grid {
-		  grid-template-columns: repeat(6, 1fr);
-		}
+                .up-next-card {
+                  grid-column: auto;
+                }
+
+                .grid {
+                  grid-template-columns: repeat(6, 1fr);
+                }
 
 		.col-4,
 		.col-6,


### PR DESCRIPTION
## Summary
- ensure the Up Next card in the hero spans the full grid width on desktop
- reset the Up Next card grid span on viewports under 900px to keep the stacked layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df5359a5e0832980abf88871cc3fd5