### PR TITLE
Add light mode host palettes and theme-aware skinning

### DIFF
--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ const HOST_THEMES = {
   autodj: {
     label: 'AutoDJ',
     aliases: ['auto', 'automation', 'radio-bot', 'amp'],
-    vars: {
+    darkVars: {
       '--brand-h': '330',
       '--brand-s': '100%',
       '--brand-l': '60%',
@@ -1196,13 +1196,24 @@ const HOST_THEMES = {
       '--muted': '#97a1b3',
       '--border': '#283042'
     },
+    lightVars: {
+      '--brand-h': '330',
+      '--brand-s': '92%',
+      '--brand-l': '58%',
+      '--bg': '#fff5fb',
+      '--surface': '#ffeefd',
+      '--surface-2': '#f9e0f2',
+      '--text': '#1a0b17',
+      '--muted': '#815a78',
+      '--border': '#f4c7e6'
+    },
     accentSvg: 'data:image/svg+xml;utf8,<svg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%20280%20220%22><defs><linearGradient%20id=%22g%22%20x1=%220%%22%20y1=%220%%22%20x2=%22100%%22%20y2=%22100%%22><stop%20offset=%220%%22%20stop-color=%22%23ff4db8%22/><stop%20offset=%22100%%22%20stop-color=%22%23ff8a1f%22/></linearGradient></defs><path%20fill=%22url(%23g)%22%20d=%22M30%200h190l60%20120-80%20100H40L0%20120z%22/></svg>',
     texture: 'radial-gradient(circle at 18% 18%, rgba(255, 77, 184, 0.22), transparent 62%)'
   },
   miki: {
     label: 'Miki',
     aliases: ['miki-rivers', 'miki-show'],
-    vars: {
+    darkVars: {
       '--brand-h': '195',
       '--brand-s': '100%',
       '--brand-l': '58%',
@@ -1213,13 +1224,24 @@ const HOST_THEMES = {
       '--muted': '#8eb5d0',
       '--border': '#103347'
     },
+    lightVars: {
+      '--brand-h': '195',
+      '--brand-s': '96%',
+      '--brand-l': '52%',
+      '--bg': '#f1fbff',
+      '--surface': '#e4f5ff',
+      '--surface-2': '#d6ecfb',
+      '--text': '#041621',
+      '--muted': '#48738c',
+      '--border': '#b0d9ef'
+    },
     accentSvg: 'data:image/svg+xml;utf8,<svg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%20260%20200%22><defs><linearGradient%20id=%22g%22%20x1=%2220%%22%20y1=%220%%22%20x2=%22100%%22%20y2=%2280%%22><stop%20offset=%220%%22%20stop-color=%22%2325d6ff%22/><stop%20offset=%22100%%22%20stop-color=%22%238c4dff%22/></linearGradient></defs><path%20fill=%22url(%23g)%22%20d=%22M0%2040%20120%200l140%2080-80%20120H40z%22/><circle%20cx=%2270%22%20cy=%22110%22%20r=%2226%22%20fill=%22rgba(255,255,255,0.45)%22/><circle%20cx=%22170%22%20cy=%2270%22%20r=%2218%22%20fill=%22rgba(255,255,255,0.36)%22/></svg>',
     texture: 'radial-gradient(circle at 75% 20%, rgba(37, 214, 255, 0.18), transparent 58%)'
   },
   jax: {
     label: 'Jax',
     aliases: ['jax-drive', 'jax-miki'],
-    vars: {
+    darkVars: {
       '--brand-h': '25',
       '--brand-s': '100%',
       '--brand-l': '64%',
@@ -1230,13 +1252,24 @@ const HOST_THEMES = {
       '--muted': '#d1a1ac',
       '--border': '#3c1d27'
     },
+    lightVars: {
+      '--brand-h': '25',
+      '--brand-s': '98%',
+      '--brand-l': '58%',
+      '--bg': '#fff8f5',
+      '--surface': '#ffefe9',
+      '--surface-2': '#ffe3d9',
+      '--text': '#32110d',
+      '--muted': '#a87062',
+      '--border': '#f5c6b5'
+    },
     accentSvg: 'data:image/svg+xml;utf8,<svg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%20260%20200%22><defs><linearGradient%20id=%22g%22%20x1=%220%%22%20y1=%220%%22%20x2=%22100%%22%20y2=%22100%%22><stop%20offset=%220%%22%20stop-color=%22%23ffd166%22/><stop%20offset=%22100%%22%20stop-color=%22%23ff006e%22/></linearGradient></defs><path%20fill=%22url(%23g)%22%20d=%22M30%2020h170l60%2090-120%2090L0%20140z%22/><path%20fill=%22rgba(255,255,255,0.35)%22%20d=%22m80%2040%20120%2040-50%2080-130-40z%22/></svg>',
     texture: 'radial-gradient(circle at 82% 22%, rgba(255, 0, 110, 0.18), transparent 60%)'
   },
   sam: {
     label: 'Sam',
     aliases: ['sam-carter', 'midnight-flow'],
-    vars: {
+    darkVars: {
       '--brand-h': '250',
       '--brand-s': '88%',
       '--brand-l': '60%',
@@ -1247,13 +1280,24 @@ const HOST_THEMES = {
       '--muted': '#9aa2cc',
       '--border': '#171c3a'
     },
-    accentSvg: 'data:image/svg+xml;utf8,<svg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%20260%20200%22><defs><linearGradient%20id=%22g%22%20x1=%2220%%22%20y1=%220%%22%20x2=%22100%%22%20y2=%22100%%22><stop%20offset=%220%%22%20stop-color=%22%233a86ff%22/><stop%20offset=%22100%%22%20stop-color=%22%238338ec%22/></linearGradient></defs><path%20fill=%22url(%23g)%22%20d=%22M0%2060%20140%200l120%20120-100%2080H40z%22/><path%20fill=%22rgba(255,255,255,0.4)%22%20d=%22M40%20120c40-30%2090-40%20140-10l-40%2060z%22/></svg>',
+    lightVars: {
+      '--brand-h': '250',
+      '--brand-s': '82%',
+      '--brand-l': '58%',
+      '--bg': '#f4f6ff',
+      '--surface': '#e9ecff',
+      '--surface-2': '#dde2ff',
+      '--text': '#11163a',
+      '--muted': '#5f6ba3',
+      '--border': '#c3caf1'
+    },
+    accentSvg: 'data:image/svg+xml;utf8,<svg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%20260%20200%22><defs><linearGradient%20id=%22g%22%20x1=%2220%%22%20y1=%220%%22%20x2=%22100%%22%20y2=%22100%%22><stop%20offset=%220%%22%20stop-color=%22%233a86ff%22/><stop%20offset=%22100%%22%20stop-color=%22%238338ec%22/></linearGradient></defs><path%20fill=%22url(%23g)%22%20d=%22M0%2060%20140%200l120%20120-100%2080H40z%22/><path%20fill=%22rgba(255,255,255,0.4)%22%20d=%22M40%20120c40-30%2090-40%20140-10l-20%2060-120%2020z%22/></svg>',
     texture: 'radial-gradient(circle at 20% 30%, rgba(58, 134, 255, 0.18), transparent 55%)'
   },
   live: {
     label: 'Live',
     aliases: ['live', 'special-guest', 'guest'],
-    vars: {
+    darkVars: {
       '--brand-h': '335',
       '--brand-s': '100%',
       '--brand-l': '58%',
@@ -1263,6 +1307,17 @@ const HOST_THEMES = {
       '--text': '#ffe8f2',
       '--muted': '#f28cb6',
       '--border': '#3d0c23'
+    },
+    lightVars: {
+      '--brand-h': '335',
+      '--brand-s': '96%',
+      '--brand-l': '56%',
+      '--bg': '#fff4f8',
+      '--surface': '#ffe6ef',
+      '--surface-2': '#ffd7e5',
+      '--text': '#35101f',
+      '--muted': '#b35a7e',
+      '--border': '#f5b7cd'
     },
     accentSvg: 'data:image/svg+xml;utf8,<svg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%20260%20200%22><defs><radialGradient%20id=%22g%22%20cx=%2250%%22%20cy=%2240%%22%20r=%2275%%22><stop%20offset=%220%%22%20stop-color=%22%23ff006e%22/><stop%20offset=%22100%%22%20stop-color=%22%23f72585%22/></radialGradient></defs><path%20fill=%22url(%23g)%22%20d=%22M20%200h200l40%20120-120%2080L0%20140z%22/><circle%20cx=%2290%22%20cy=%2280%22%20r=%2224%22%20fill=%22rgba(255,255,255,0.35)%22/></svg>',
     texture: 'radial-gradient(circle at 12% 25%, rgba(247, 37, 133, 0.22), transparent 60%)'
@@ -1332,9 +1387,23 @@ const resolveHostThemeSlug = (hostName, { asSlug = false } = {}) => {
 const applyHostSkin = (() => {
   let lastSlug = '';
 
-  const setRootVars = (vars = {}) => {
-    const rootStyle = document.documentElement.style;
-    const merged = { ...(HOST_THEMES[DEFAULT_HOST_SLUG]?.vars || {}), ...vars };
+  const setRootVars = (theme = {}) => {
+    const root = document.documentElement;
+    const rootStyle = root.style;
+    const mode = root.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+    const variantKey = mode === 'light' ? 'lightVars' : 'darkVars';
+
+    const defaultTheme = HOST_THEMES[DEFAULT_HOST_SLUG] || {};
+    const baseVars = defaultTheme[variantKey]
+      || defaultTheme.darkVars
+      || defaultTheme.lightVars
+      || {};
+    const activeVars = theme[variantKey]
+      || theme.darkVars
+      || theme.lightVars
+      || {};
+
+    const merged = { ...baseVars, ...activeVars };
     for (const [prop, value] of Object.entries(merged)) {
       if (value == null) rootStyle.removeProperty(prop);
       else rootStyle.setProperty(prop, value);
@@ -1368,7 +1437,7 @@ const applyHostSkin = (() => {
     if (slug === lastSlug && !opts.force) return;
 
     const theme = HOST_THEMES[slug] || HOST_THEMES[DEFAULT_HOST_SLUG];
-    setRootVars(theme?.vars);
+    setRootVars(theme);
     setAccentAssets(slug, {
       accentSvg: theme?.accentSvg ?? HOST_THEMES[DEFAULT_HOST_SLUG]?.accentSvg,
       texture: theme?.texture ?? HOST_THEMES[DEFAULT_HOST_SLUG]?.texture
@@ -1676,6 +1745,9 @@ function initHeaderUI() {
         ? '<path fill-rule="evenodd" clip-rule="evenodd" d="M12 3a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1Zm7 9a7 7 0 1 1-7-7 5 5 0 0 0 0 10 7 7 0 0 1 7-3Z"/>'
         : '<path d="M17.6 15.6A7 7 0 0 1 8.4 6.4 7 7 0 1 0 17.6 15.6Z"/>';
     }
+
+    const activeHost = document.documentElement.dataset.hostTheme || DEFAULT_HOST_SLUG;
+    applyHostSkin(activeHost, { asSlug: true, force: true, skipPersist: true });
   };
 
   themeBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add dedicated dark and light variable sets for each host palette so colors adapt to the active theme
- update host skin application to pick the correct variant based on the current data-theme attribute
- reapply the saved host skin after theme toggles to keep gradients and accents in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df58000ea083298aa63112785924d1