### PR TITLE
Revamp up-next schedule layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,15 @@
                 --r-sm: 10px;
                 --max: 1100px;
                 --promo-texture: none;
+                --layer-card-bg: linear-gradient(145deg,
+                      color-mix(in oklab, var(--surface-2) 92%, transparent),
+                      color-mix(in oklab, var(--surface) 88%, transparent)
+                );
+                --layer-card-overlay: radial-gradient(120% 120% at 22% 12%, hsl(var(--brand-h) 92% 58% / .45), transparent 65%);
+                --layer-border: color-mix(in oklab, var(--border) 70%, transparent);
+                --layer-glass: color-mix(in oklab, var(--surface) 82%, transparent);
+                --layer-hover-bg: color-mix(in oklab, var(--surface-2) 88%, transparent);
+                --layer-chip-bg: color-mix(in oklab, var(--surface) 75%, transparent);
           }
 
           @keyframes heroFadeUp {
@@ -81,15 +90,24 @@
                 to   { transform: rotate(360deg); }
           }
 
-	  [data-theme="light"] {
-		--bg: #fbf7fb;
-		--surface: #fff;
-		--surface-2: #f5f0f6;
-		--text: #0d1117;
-		--muted: #505b6d;
-		--border: #e2cfe2;
-		--shadow: 0 10px 30px rgba(10, 20, 40, .08);
-	  }
+          [data-theme="light"] {
+                --bg: #fbf7fb;
+                --surface: #fff;
+                --surface-2: #f5f0f6;
+                --text: #0d1117;
+                --muted: #505b6d;
+                --border: #e2cfe2;
+                --shadow: 0 10px 30px rgba(10, 20, 40, .08);
+                --layer-card-bg: linear-gradient(145deg,
+                      color-mix(in oklab, var(--surface-2) 90%, rgba(255, 255, 255, .6)),
+                      color-mix(in oklab, var(--surface) 98%, transparent)
+                );
+                --layer-card-overlay: radial-gradient(120% 120% at 22% 12%, hsl(var(--brand-h) 95% 72% / .35), transparent 70%);
+                --layer-border: color-mix(in oklab, var(--border) 55%, transparent);
+                --layer-glass: color-mix(in oklab, var(--surface) 94%, rgba(255, 255, 255, .25));
+                --layer-hover-bg: color-mix(in oklab, var(--surface-2) 95%, rgba(255, 255, 255, .3));
+                --layer-chip-bg: color-mix(in oklab, var(--surface) 92%, rgba(255, 255, 255, .25));
+          }
 
 	  * {
 		box-sizing: border-box;
@@ -438,45 +456,113 @@
           }
 
           .up-next-card {
+                --card-bg: var(--layer-card-bg);
+                --card-border: var(--layer-border);
+                --card-shadow: 0 26px 60px color-mix(in srgb, #000 40%, transparent);
+                --card-body-bg: transparent;
+                --card-body-padding: clamp(24px, 5vw, 32px);
+                --card-body-gap: clamp(22px, 4vw, 28px);
                 margin-top: 18px;
                 grid-column: 1 / -1;
+                position: relative;
+                isolation: isolate;
                 animation-delay: .35s;
           }
 
+          .up-next-card::before {
+                content: "";
+                position: absolute;
+                inset: -40% -30% 40% -30%;
+                background: var(--layer-card-overlay);
+                filter: blur(28px);
+                opacity: .85;
+                z-index: 0;
+                pointer-events: none;
+          }
+
+          .up-next-card .body {
+                position: relative;
+                z-index: 1;
+                display: grid;
+          }
+
           .current-show {
-                display: flex;
-                align-items: center;
-                gap: 12px;
-                padding: 12px;
-                border: 1px solid var(--border);
-                border-radius: var(--r-md);
-                background: var(--surface-2);
+                position: relative;
+                display: grid;
+                grid-template-columns: minmax(0, 1fr);
+                grid-template-rows: auto auto;
+                gap: clamp(18px, 4vw, 24px);
+                padding: clamp(22px, 5vw, 30px);
+                border-radius: calc(var(--r-lg) - 2px);
+                background: var(--layer-glass);
+                border: 1px solid color-mix(in oklab, var(--layer-border) 85%, transparent);
+                box-shadow: 0 20px 48px color-mix(in srgb, #000 35%, transparent);
+                backdrop-filter: blur(18px) saturate(1.3);
+                overflow: hidden;
+                isolation: isolate;
+          }
+
+          .current-show::before {
+                content: "";
+                position: absolute;
+                inset: -55% -35% 15% -35%;
+                background: radial-gradient(120% 120% at 20% 18%, hsl(var(--brand-h) 96% 66% / .55), transparent 65%);
+                filter: blur(32px);
+                opacity: .9;
+                z-index: 0;
+          }
+
+          .current-show > * {
+                position: relative;
+                z-index: 1;
           }
 
           .current-show-badge {
-                flex-shrink: 0;
+                justify-self: start;
+                padding: .45rem 1.05rem;
+                border-radius: 999px;
+                font-size: .8rem;
+                letter-spacing: .14em;
+                text-transform: uppercase;
+                font-weight: 700;
+                background: linear-gradient(135deg, var(--brand-300), var(--brand));
+                color: #0a030f;
+                box-shadow:
+                  0 0 0 1px color-mix(in oklab, #fff 65%, transparent),
+                  0 0 22px hsl(var(--brand-h) 95% 65% / .45);
           }
 
           .current-show-text {
                 display: grid;
-                gap: 4px;
+                gap: clamp(8px, 2vw, 12px);
+                max-width: 48ch;
           }
 
           .current-show-title {
                 margin: 0;
-                font-size: 1rem;
+                font-size: clamp(1.55rem, 1.5vw + 1.1rem, 2.2rem);
+                font-weight: 700;
+                letter-spacing: -.01em;
+                line-height: 1.2;
+                text-wrap: balance;
           }
 
           .current-show-time {
-                color: var(--muted);
-                font-size: .85rem;
+                color: color-mix(in oklab, var(--text) 70%, var(--muted) 30%);
+                font-size: clamp(1.05rem, 1vw + .9rem, 1.25rem);
+                font-weight: 600;
+                line-height: 1.35;
+                text-wrap: balance;
           }
 
           .up-next-head {
                 display: flex;
+                flex-wrap: wrap;
                 align-items: center;
                 justify-content: space-between;
-                gap: .6rem;
+                gap: 1rem;
+                padding-bottom: 12px;
+                border-bottom: 1px solid color-mix(in oklab, var(--layer-border) 55%, transparent);
           }
 
           .up-next-list {
@@ -484,19 +570,39 @@
                 padding: 0;
                 margin: 0;
                 display: grid;
-                gap: 10px;
+                gap: 16px;
                 counter-reset: upnext;
           }
 
           .up-next-item {
                 counter-increment: upnext;
+                position: relative;
                 display: flex;
                 align-items: center;
-                gap: 12px;
-                padding: 10px 12px;
-                border: 1px solid var(--border);
+                gap: 16px;
+                padding: 16px 18px;
                 border-radius: var(--r-md);
-                background: var(--surface-2);
+                background: color-mix(in oklab, var(--layer-glass) 90%, transparent);
+                border: 1px solid color-mix(in oklab, var(--layer-border) 60%, transparent);
+                box-shadow: 0 10px 28px color-mix(in srgb, #000 22%, transparent);
+                backdrop-filter: blur(12px) saturate(1.15);
+                transition: transform .2s ease, box-shadow .25s ease, border-color .2s ease, background .2s ease;
+                flex-wrap: wrap;
+          }
+
+          .up-next-item:hover,
+          .up-next-item:focus-within {
+                transform: translateY(-2px);
+                border-color: color-mix(in oklab, var(--layer-border) 40%, var(--brand) 20%);
+                background: color-mix(in oklab, var(--layer-hover-bg) 85%, transparent);
+                box-shadow:
+                  0 16px 34px color-mix(in srgb, #000 28%, transparent),
+                  0 0 18px hsl(var(--brand-h) 92% 60% / .2);
+          }
+
+          .up-next-item:focus-within {
+                outline: 2px solid color-mix(in oklab, var(--brand) 55%, transparent);
+                outline-offset: 4px;
           }
 
           .recent-item {
@@ -522,37 +628,42 @@
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
-                width: 30px;
-                height: 30px;
+                width: 34px;
+                height: 34px;
                 border-radius: 999px;
-                background: linear-gradient(135deg, var(--brand-300), var(--brand));
-                color: #000;
+                background: linear-gradient(140deg, var(--brand-300), var(--brand));
+                color: #0b040f;
                 font-weight: 700;
                 font-variant-numeric: tabular-nums;
-                box-shadow: 0 0 0 1px rgba(0, 0, 0, .12);
+                box-shadow: 0 0 0 1px color-mix(in oklab, #fff 60%, transparent);
                 flex-shrink: 0;
           }
 
           .up-next-text {
                 display: grid;
-                gap: 4px;
+                gap: 6px;
+                flex: 1 1 220px;
+                min-width: 0;
           }
 
           .up-next-title {
                 margin: 0;
-                font-size: .98rem;
+                font-size: 1.02rem;
+                font-weight: 600;
           }
 
           .up-next-meta {
-                color: var(--muted);
-                font-size: .82rem;
+                color: color-mix(in oklab, var(--muted) 70%, var(--text) 30%);
+                font-size: .88rem;
           }
 
           .up-next-chip {
-                background: var(--surface);
-                border-color: color-mix(in srgb, var(--border) 70%, transparent);
+                background: var(--layer-chip-bg);
+                border-color: color-mix(in oklab, var(--layer-border) 55%, transparent);
                 color: var(--text);
                 font-weight: 600;
+                backdrop-filter: blur(10px) saturate(1.1);
+                flex-shrink: 0;
           }
 
 	  .now {
@@ -769,17 +880,36 @@
 
                 .up-next-card {
                   grid-column: auto;
+                  --card-body-gap: clamp(20px, 6vw, 28px);
+                  --card-body-padding: clamp(22px, 7vw, 30px);
+                }
+
+                .current-show {
+                  padding: clamp(20px, 7vw, 30px);
+                }
+
+                .current-show-title {
+                  font-size: clamp(1.45rem, 4vw + 1rem, 2.05rem);
                 }
 
                 .grid {
                   grid-template-columns: repeat(6, 1fr);
                 }
 
-		.col-4,
-		.col-6,
-		.col-8 {
-		  grid-column: span 6;
-		}
+                .col-4,
+                .col-6,
+                .col-8 {
+                  grid-column: span 6;
+                }
+
+                .up-next-head {
+                  align-items: flex-start;
+                  gap: .75rem;
+                }
+
+                .up-next-item {
+                  align-items: flex-start;
+                }
 
                 .logo-img {
                   width: 130px;
@@ -846,6 +976,28 @@
                 .player-volume input[type="range"] {
                   width: 100%;
                 }
+
+                .up-next-item {
+                  flex-direction: column;
+                  align-items: flex-start;
+                  gap: 12px;
+                }
+
+                .up-next-item::before {
+                  margin-bottom: 4px;
+                }
+
+                .up-next-chip {
+                  font-size: .78rem;
+                }
+
+                .up-next-text {
+                  width: 100%;
+                }
+
+                .current-show {
+                  padding: clamp(18px, 8vw, 28px);
+                }
           }
 
 	  .skip {
@@ -871,10 +1023,10 @@
 
           /* Card stays solid on all themes */
           .card {
-                background: var(--surface);
-                border: 1px solid var(--border);
-                border-radius: var(--r-lg);
-                box-shadow: var(--shadow);
+                background: var(--card-bg, var(--surface));
+                border: 1px solid var(--card-border, var(--border));
+                border-radius: var(--card-radius, var(--r-lg));
+                box-shadow: var(--card-shadow, var(--shadow));
                 overflow: clip;
                 display: flex;
                 flex-direction: column;
@@ -885,7 +1037,7 @@
           .card:focus-within {
                 transform: translateY(-6px);
                 box-shadow:
-                  var(--shadow),
+                  var(--card-shadow, var(--shadow)),
                   0 20px 40px hsl(var(--brand-h) 95% 55% / .25);
           }
 
@@ -899,12 +1051,12 @@
 	  }
 
 	  /* Text area */
-	  .card .body {
-		background: var(--surface);
-		padding: 14px;
-		display: grid;
-		gap: 8px;
-	  }
+          .card .body {
+                background: var(--card-body-bg, var(--surface));
+                padding: var(--card-body-padding, 14px);
+                display: grid;
+                gap: var(--card-body-gap, 8px);
+          }
 
 	  /* Image + placeholder */
 	  .card .media img {


### PR DESCRIPTION
## Summary
- introduce layered gradient variables to give the up-next module a theme-aware glass treatment
- redesign the current show hero tile and upcoming list with richer typography, spacing, and interactive states
- tune responsive breakpoints so the current show stacks cleanly above upcoming items on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df6cbe0c748329a371134a098f3c43