### PR TITLE
Add car mode toggle for enlarged player controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="dark" data-car-mode="false">
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -395,6 +395,88 @@
           .promo-card .player-volume {
                 margin-top: 1.2rem;
                 width: 100%;
+          }
+
+          [data-car-mode="true"] .hero .wrap {
+                grid-template-columns: 1fr;
+          }
+
+          [data-car-mode="true"] .player-controls {
+                flex-direction: column;
+                align-items: stretch;
+                gap: 1rem;
+                max-width: 360px;
+          }
+
+          [data-car-mode="true"] .player-controls .btn {
+                font-size: 1.15rem;
+                padding: 1rem 1.35rem;
+                justify-content: center;
+                width: 100%;
+          }
+
+          [data-car-mode="true"] .player-controls .btn svg {
+                width: 26px;
+                height: 26px;
+          }
+
+          #carModeToggle svg {
+                width: 20px;
+                height: 20px;
+          }
+
+          [data-car-mode="true"] #carModeToggle {
+                font-size: 1.15rem;
+          }
+
+          [data-car-mode="true"] #carModeToggle svg {
+                width: 28px;
+                height: 28px;
+          }
+
+          [data-car-mode="true"] .player-volume {
+                flex-direction: column;
+                align-items: stretch;
+                gap: 1rem;
+                font-size: 1.05rem;
+                padding: 1.1rem 1.35rem;
+          }
+
+          [data-car-mode="true"] .player-volume label {
+                font-size: 1rem;
+          }
+
+          [data-car-mode="true"] .player-volume-controls {
+                flex-direction: column;
+                align-items: stretch;
+                gap: 0.9rem;
+          }
+
+          [data-car-mode="true"] .player-volume input[type="range"] {
+                min-width: 220px;
+                transform: scale(1.1);
+                transform-origin: left center;
+          }
+
+          [data-car-mode="true"] .player-volume .icon-btn {
+                width: 52px;
+                height: 52px;
+          }
+
+          [data-car-mode="true"] .promo-card h3#trackTitle {
+                font-size: clamp(1.6rem, 1.3rem + 1vw, 2.2rem);
+          }
+
+          [data-car-mode="true"] #trackMeta {
+                font-size: 1.1rem;
+          }
+
+          [data-car-mode="true"] .progress {
+                height: 12px;
+          }
+
+          [data-car-mode="true"] #upNextCard {
+                display: none;
           }
 
           .promo-card {
@@ -1005,6 +1087,13 @@
                   </svg>
                   <span>Play Stream</span>
                 </button>
+                <button id="carModeToggle" class="btn btn-ghost" type="button" aria-pressed="false" aria-label="Enable car mode" title="Enable car mode">
+                  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                    <path d="M5.2 11.3 6.4 7.8A2 2 0 0 1 8.3 6.5h7.4a2 2 0 0 1 1.9 1.3l1.3 3.5A3 3 0 0 1 22 14v3a1 1 0 0 1-1 1h-1.1a2 2 0 0 1-3.8 0H7.9a2 2 0 0 1-3.8 0H3a1 1 0 0 1-1-1v-3a3 3 0 0 1 3.2-2.7ZM6.6 11h10.8l-.9-2.7a1 1 0 0 0-1-.7H8.5a1 1 0 0 0-1 .7L6.6 11ZM6.5 17a1 1 0 1 0 0-.01V17Zm11 0a1 1 0 1 0 0-.01V17Z"/>
+                  </svg>
+                  <span>Car Mode</span>
+                </button>
+                <span id="carModeHint" class="sr-only">Car mode enlarges the player controls and hides secondary content for easier in-car use.</span>
               </div>
               <a class="btn btn-ghost" href="#schedule">View Schedule</a>
               <a class="btn btn-ghost" href="#recent">Recently Played</a>
@@ -1804,6 +1893,51 @@ function initHeaderUI() {
   });
 }
 
+/* ---------------------------- CAR MODE -------------------------------- */
+function initCarModeToggle() {
+  const toggleBtn = $('#carModeToggle');
+  const root = document.documentElement;
+  if (!toggleBtn || !root) return;
+
+  const STORAGE_KEY = 'amped-car-mode';
+  const textSpan = toggleBtn.querySelector('span');
+
+  const setState = (active, { emit = true } = {}) => {
+    const next = active ? 'true' : 'false';
+    root.setAttribute('data-car-mode', next);
+    toggleBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    const label = active ? 'Disable car mode' : 'Enable car mode';
+    toggleBtn.setAttribute('aria-label', label);
+    toggleBtn.setAttribute('title', label);
+    if (textSpan) {
+      textSpan.textContent = active ? 'Car Mode On' : 'Car Mode';
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch (err) {
+      /* ignore */
+    }
+    if (emit) {
+      document.dispatchEvent(new CustomEvent('car-mode-change', { detail: { active } }));
+    }
+  };
+
+  toggleBtn.addEventListener('click', () => {
+    const current = root.getAttribute('data-car-mode') === 'true';
+    setState(!current);
+  });
+
+  const stored = (() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch (err) {
+      return false;
+    }
+  })();
+
+  setState(stored, { emit: false });
+}
+
 /* ------------------------------ SHOW GRID ------------------------------ */
 function renderShows() {
   const grid = document.getElementById('showsGrid');
@@ -1947,6 +2081,9 @@ function initPlayer() {
   const muteBtn      = $('#muteBtn');
   const muteIcon     = $('#muteIcon');
   const muteText     = $('#muteText');
+  const upNextCard   = $('#upNextCard');
+  const carModeHint  = $('#carModeHint');
+  const carModeHintId = carModeHint?.id || null;
 
   if (!player || !playBtn || !playIcon || !playLabel) return;
 
@@ -2194,6 +2331,36 @@ function initPlayer() {
   });
   player.addEventListener('playing', () => { clearTimeout(waitingTimer); });
   player.addEventListener('timeupdate', () => { clearTimeout(waitingTimer); });
+
+  const applyCarModeAccessibility = (active, { focusControl = false } = {}) => {
+    const controls = [playBtn, volumeSlider, muteBtn];
+    controls.forEach(ctrl => {
+      if (!ctrl) return;
+      if (active && carModeHintId) {
+        ctrl.setAttribute('aria-describedby', carModeHintId);
+      } else if (carModeHintId && ctrl.getAttribute('aria-describedby') === carModeHintId) {
+        ctrl.removeAttribute('aria-describedby');
+      }
+    });
+    if (upNextCard) {
+      upNextCard.setAttribute('aria-hidden', active ? 'true' : 'false');
+    }
+    if (focusControl && active) {
+      try {
+        playBtn.focus({ preventScroll: true });
+      } catch (err) {
+        /* ignore */
+      }
+    }
+  };
+
+  document.addEventListener('car-mode-change', (event) => {
+    const active = Boolean(event?.detail?.active);
+    applyCarModeAccessibility(active, { focusControl: true });
+  });
+
+  const initialCarMode = document.documentElement.getAttribute('data-car-mode') === 'true';
+  applyCarModeAccessibility(initialCarMode);
 }
 
 /* ----------------------- NOW PLAYING / RECENTS ------------------------- */
@@ -2352,6 +2519,7 @@ function initNowPlaying() {
 /* ------------------------------ INIT ----------------------------------- */
 function init() {
   initHeaderUI();
+  initCarModeToggle();
   renderShows();
   renderScheduleShell();
   const tz = STATION_TZ;


### PR DESCRIPTION
## Summary
- add a car mode toggle to the hero controls and persist the chosen state
- style the layout for car mode to enlarge key controls and hide the schedule card
- update the audio player logic to react to car mode changes with accessibility adjustments

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df6ce238548329b23c0b7fda9fa816