### PR TITLE
Fix car mode volume slider layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
           [data-car-mode="true"] .player-volume {
                 flex-direction: column;
                 align-items: stretch;
-                gap: 1rem;
+                gap: 0.9rem;
                 font-size: 1.05rem;
                 padding: 1.1rem 1.35rem;
           }
@@ -466,14 +466,14 @@
 
           [data-car-mode="true"] .player-volume-controls {
                 flex-direction: column;
-                align-items: stretch;
+                align-items: center;
                 gap: 0.9rem;
           }
 
           [data-car-mode="true"] .player-volume input[type="range"] {
-                min-width: 220px;
-                transform: scale(1.1);
-                transform-origin: left center;
+                width: 100%;
+                flex: 1;
+                min-width: 0;
           }
 
           [data-car-mode="true"] .player-volume .icon-btn {


### PR DESCRIPTION
## Summary
- let the car mode volume slider use the full container width without scaling distortions
- tweak car mode volume control spacing to keep the mute button centered beneath the slider

## Testing
- manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68df7182c8d88329a0f212ee99721da7