### PR TITLE
Hide navigation when car mode is active

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,12 +223,12 @@
 		border-bottom: 1px solid var(--border);
 	  }
 
-	  .header .row {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: .7rem 0;
-	  }
+          .header .row {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                padding: .7rem 0;
+          }
 
 	  .logo {
 		display: inline-flex;
@@ -265,11 +265,11 @@
 		text-decoration: none;
 	  }
 
-	  .header-actions {
-		display: flex;
-		align-items: center;
-		gap: .6rem;
-	  }
+          .header-actions {
+                display: flex;
+                align-items: center;
+                gap: .6rem;
+          }
 
 	  .icon-btn {
 		display: inline-grid;
@@ -300,6 +300,19 @@
 
           .menu-toggle {
                 display: none;
+          }
+
+          [data-car-mode="true"] #site-nav,
+          [data-car-mode="true"] .header-actions {
+                display: none;
+          }
+
+          [data-car-mode="true"] .header .row {
+                justify-content: center;
+          }
+
+          [data-car-mode="true"] .logo-img {
+                width: 190px;
           }
 
 	  .hero {


### PR DESCRIPTION
## Summary
- hide the header navigation and action buttons when car mode is enabled while keeping the logo visible and centered
- enlarge the logo image in car mode to improve visibility when it is the only header element

## Testing
- browser_container.run_playwright_script (toggle car mode)


------
https://chatgpt.com/codex/tasks/task_e_68df718f9c60832996f8434787919fc0