### PR TITLE
Refine Up Next layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1160,21 +1160,27 @@
                 }
 
                 .up-next-item {
-                  flex-direction: column;
-                  align-items: flex-start;
-                  gap: 12px;
+                  display: grid;
+                  grid-template-columns: auto 1fr;
+                  gap: 10px 12px;
+                  align-items: start;
+                  padding: 14px 16px;
                 }
 
                 .up-next-item::before {
-                  margin-bottom: 4px;
+                  margin: 0;
+                  align-self: start;
                 }
 
                 .up-next-chip {
                   font-size: .78rem;
+                  justify-self: start;
                 }
 
                 .up-next-text {
+                  grid-column: 1 / -1;
                   width: 100%;
+                  min-width: 0;
                 }
 
                 .current-show {


### PR DESCRIPTION
## Summary
- switch the mobile Up Next items to a compact grid layout so show titles keep their width without inflating card height
- align the count badge and time chip for small screens to prevent the titles from being squished

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0dce4bd08832985200c9928c8e72d