### PR TITLE
Hide hero text when car mode is active

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,6 +555,12 @@
                 grid-template-columns: 1fr;
           }
 
+          [data-car-mode="true"] .hero .eyebrow,
+          [data-car-mode="true"] .hero h1,
+          [data-car-mode="true"] .hero p {
+                display: none;
+          }
+
           [data-car-mode="true"] .player-controls {
                 flex-direction: column;
                 align-items: stretch;


### PR DESCRIPTION
## Summary
- hide the hero eyebrow, headline, and paragraph when car mode is enabled to declutter the interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6213f38188329a378517e1f415f7b